### PR TITLE
Set correct working directory for target application

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Windows 10 1709 或以系统下 需要 [.NET Framework 4.7.2](https://go.microso
 
 # 使用方法
 
-- `URLProtocol.exe` 复制到你想要调用的程序目录
 - 打开`URLProtocol.exe` 填写 协议名(不包含 ":")
 - 点击 选择目标程序 选择你要调用的 exe 文件
 - 点击 添加/更新
@@ -58,7 +57,6 @@ Windows 10 1709 or later requires [.NET Framework 4.7.2](https://go.microsoft.co
 
 # Usage
 
-- Copy `URLProtocol.exe` to the directory of the program you want to call.
 - Open `URLProtocol.exe` and fill in the protocol name (excluding ":").
 - Click Select Target Program and choose the exe file you want to call.
 - Click Add/Update.

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -51,7 +51,7 @@ namespace URLProtocol
                     {
                         FileName = program, // 程序
                         Arguments = parameters, // 参数
-                        WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory    // 调整工作目录
+                        WorkingDirectory = System.IO.Path.GetDirectoryName(program)    // 调整工作目录
                     };
                     Process.Start(startInfo);
                 }


### PR DESCRIPTION
This pull request fixes an issue where applications launched via a custom URL protocol would inherit URLProtocol.exe’s directory instead of using their own directory.

The change updates App.xaml.cs to set WorkingDirectory to the target executable’s directory. This ensures that the launched application starts in its own directory, matching the behaviour when double‑clicking the executable.

The README has also been updated to remove the outdated instruction to copy URLProtocol.exe into the target application’s directory, as this workaround is no longer required.